### PR TITLE
fix: backup and restore scripts

### DIFF
--- a/scripts/dump-rds-to-s3.sh
+++ b/scripts/dump-rds-to-s3.sh
@@ -65,6 +65,8 @@ trap 'handle_error $?' ERR
 
 # https://docs.aws.amazon.com/dms/latest/sbs/chap-manageddatabases.postgresql-rds-postgresql-full-load-pd_dump.html
 # https://aws.amazon.com/blogs/database/best-practices-for-migrating-postgresql-databases-to-amazon-rds-and-amazon-aurora/
+# https://stackoverflow.com/a/46577479/5371505
+export AWS_DEFAULT_REGION="us-east-1"
 export PGPASSFILE="$HOME/.pgpass"
 backup_dirname="$(date '+%Y_%m_%d_%HH_%MM_%SS')"
 bucket_url="s3://test-ch-backups-rds"

--- a/scripts/restore-rds-to-docker.sh
+++ b/scripts/restore-rds-to-docker.sh
@@ -73,7 +73,8 @@ trap 'handle_error $?' ERR
 
 # trap error
 # trap exit
-
+# https://stackoverflow.com/a/46577479/5371505
+export AWS_DEFAULT_REGION="us-east-1"
 bucket='test-ch-backups-rds'
 container_name="my_postgres_container"
 globals_filename="globals.dump"


### PR DESCRIPTION
# Description

Fix backup and restore scripts by adding an export for AWS_DEFAULT_REGION and set it to us-east-1 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] My code follows the style guidelines of this project
- [x] I've run the linter locally.
- [x] I've run the project locally using development environment.
